### PR TITLE
Add permissions and note to the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ You can do this by going to your repository/organization's settings, navigate to
 ### Step 2: Adjust Permissions
 
 Then you need to set up your project's permissions so that the Github Actions can write comments on Pull Requests. You can read more about this here: [automatic-token-authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)
+**NOTE:** alternatively you can add temporary permissions directly in the github action as shown in the example below.
 
 ### Step 3: Create a new Github Actions workflow in your repository in `.github/workflows/chatgpt-review.yaml. A sample workflow is given below:
 
@@ -28,6 +29,11 @@ Then you need to set up your project's permissions so that the Github Actions ca
 on:
   pull_request:
     types: [opened, synchronize]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
 
 jobs:
   code_review_job:


### PR DESCRIPTION
Due to the recent (I think) changes in the GITHUB_TOKEN, for security reasons, the automatically created GITHUB_TOKEN only allow read permissions unless specifically allowed.

README.md already details this, but so that people can just copy and use the example code, we may as well leverage the `permissions` property to allow temporary permissions to be granted for this specific action.

I thought by default all permissions where read only, but I was getting this error, so when using temporary permissions it removes the default and you need to specify every permission required.

```
2025-03-13 11:39:56,710 - ERROR - Error retrieving files for commit cb86da0e6b602ddd9d7b7ca49460de09434a2c48: 
403 {"message": "Resource not accessible by integration", "documentation_url": "https://docs.github.com/rest/commits/commits#get-a-commit", "status": "403"}
```