### PR TITLE
Add optional GitHub base url

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: true
     default: ''
   github_base_url:  # id of input
-    description: 'Base url for Github'
+    description: "Base url for Github in the form 'https://github.company.com/api/v3'"
     required: false
     default: ''
   openai_model:

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Github PR ID'
     required: true
     default: ''
+  github_base_url:  # id of input
+    description: 'Base url for Github'
+    required: false
+    default: ''
   openai_model:
     description: "The OpenAI model to use for generating responses. Examples: 'gpt-3.5-turbo', 'gpt-4'"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   github_base_url:  # id of input
     description: "Base url for Github in the form 'https://github.company.com/api/v3'"
     required: false
-    default: ''
+    default: 'https://api.github.com'
   openai_model:
     description: "The OpenAI model to use for generating responses. Examples: 'gpt-3.5-turbo', 'gpt-4'"
     required: false

--- a/src/clients/github_client.py
+++ b/src/clients/github_client.py
@@ -18,7 +18,7 @@ class GithubClient:
     A client for interacting with the GitHub API to manage pull requests and repository content.
     """
 
-    def __init__(self, token):
+    def __init__(self, token, base_url=None):
         """
         Initialize the GithubClient with a GitHub token.
 
@@ -26,7 +26,16 @@ class GithubClient:
             token (str): The GitHub token for authentication.
         """
         try:
-            self.client = Github(token)
+            if base_url:
+                self.client = Github(
+                    login_or_token=token,
+                    base_url=base_url
+                )
+            else:
+                self.client = Github(
+                    login_or_token=token
+                )
+
             self.repo_name = os.getenv('GITHUB_REPOSITORY')
             self.repo = self.client.get_repo(self.repo_name)
             logging.info("Initialized GitHub client for repository: %s", self.repo_name)

--- a/src/clients/github_client.py
+++ b/src/clients/github_client.py
@@ -24,6 +24,7 @@ class GithubClient:
 
         Args:
             token (str): The GitHub token for authentication.
+            base_url (str): Base url for Github. Needed for custom GHES urls.
         """
         try:
             if base_url:

--- a/src/clients/github_client.py
+++ b/src/clients/github_client.py
@@ -18,7 +18,7 @@ class GithubClient:
     A client for interacting with the GitHub API to manage pull requests and repository content.
     """
 
-    def __init__(self, token, base_url=None):
+    def __init__(self, token, base_url):
         """
         Initialize the GithubClient with a GitHub token.
 
@@ -27,16 +27,7 @@ class GithubClient:
             base_url (str): Base url for Github. Needed for custom GHES urls.
         """
         try:
-            if base_url:
-                self.client = Github(
-                    login_or_token=token,
-                    base_url=base_url
-                )
-            else:
-                self.client = Github(
-                    login_or_token=token
-                )
-
+            self.client = Github(login_or_token=token, base_url=base_url)
             self.repo_name = os.getenv('GITHUB_REPOSITORY')
             self.repo = self.client.get_repo(self.repo_name)
             logging.info("Initialized GitHub client for repository: %s", self.repo_name)

--- a/src/main.py
+++ b/src/main.py
@@ -21,7 +21,7 @@ def main():
         return
 
     if env_vars['GITHUB_BASE_URL']:
-        github_client = GithubClient(env_vars['GITHUB_TOKEN'], env_vars['GITHUB_BASEURL'])
+        github_client = GithubClient(env_vars['GITHUB_TOKEN'], env_vars['GITHUB_BASE_URL'])
     else:
         github_client = GithubClient(env_vars['GITHUB_TOKEN'])
     openai_client = OpenAIClient(env_vars['OPENAI_MODEL'],
@@ -68,7 +68,7 @@ def get_env_vars():
         'MODE': (str, True),
         'LANGUAGE': (str, True),
         'CUSTOM_PROMPT': (str, False),
-        'GITHUB_BASEURL': (str, False)
+        'GITHUB_BASE_URL': (str, False)
     }
 
     env_vars = {}

--- a/src/main.py
+++ b/src/main.py
@@ -20,10 +20,8 @@ def main():
         logging.error("Environment variable error: %s", e)
         return
 
-    if env_vars['GITHUB_BASE_URL']:
-        github_client = GithubClient(env_vars['GITHUB_TOKEN'], env_vars['GITHUB_BASE_URL'])
-    else:
-        github_client = GithubClient(env_vars['GITHUB_TOKEN'])
+    github_base_url = env_vars.get('GITHUB_BASE_URL') or 'https://api.github.com'
+    github_client = GithubClient(env_vars['GITHUB_TOKEN'], github_base_url)
     openai_client = OpenAIClient(env_vars['OPENAI_MODEL'],
                                  env_vars['OPENAI_TEMPERATURE'],
                                  env_vars['OPENAI_MAX_TOKENS'])

--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,10 @@ def main():
         logging.error("Environment variable error: %s", e)
         return
 
-    github_client = GithubClient(env_vars['GITHUB_TOKEN'])
+    if env_vars['GITHUB_BASE_URL']:
+        github_client = GithubClient(env_vars['GITHUB_TOKEN'], env_vars['GITHUB_BASEURL'])
+    else:
+        github_client = GithubClient(env_vars['GITHUB_TOKEN'])
     openai_client = OpenAIClient(env_vars['OPENAI_MODEL'],
                                  env_vars['OPENAI_TEMPERATURE'],
                                  env_vars['OPENAI_MAX_TOKENS'])
@@ -64,7 +67,8 @@ def get_env_vars():
         'OPENAI_MAX_TOKENS': (int, True),
         'MODE': (str, True),
         'LANGUAGE': (str, True),
-        'CUSTOM_PROMPT': (str, False)
+        'CUSTOM_PROMPT': (str, False),
+        'GITHUB_BASEURL': (str, False)
     }
 
     env_vars = {}

--- a/src/main.py
+++ b/src/main.py
@@ -20,8 +20,7 @@ def main():
         logging.error("Environment variable error: %s", e)
         return
 
-    github_base_url = env_vars.get('GITHUB_BASE_URL') or 'https://api.github.com'
-    github_client = GithubClient(env_vars['GITHUB_TOKEN'], github_base_url)
+    github_client = GithubClient(env_vars['GITHUB_TOKEN'], env_vars['GITHUB_BASE_URL'])
     openai_client = OpenAIClient(env_vars['OPENAI_MODEL'],
                                  env_vars['OPENAI_TEMPERATURE'],
                                  env_vars['OPENAI_MAX_TOKENS'])

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -8,6 +8,7 @@ class TestGithubClient(unittest.TestCase):
     def setUp(self):
         self.token = "fake_github_token"
         self.repo_name = "fake_repo"
+        self.repo_url = "fake_repo_url"
         self.pr_id = 1
         self.commit_sha = "fake_commit_sha"
         self.filename = "fake_file.py"
@@ -18,7 +19,7 @@ class TestGithubClient(unittest.TestCase):
         with patch('clients.github_client.Github') as MockGithub:
             self.mock_github = MockGithub.return_value
             self.mock_repo = self.mock_github.get_repo.return_value
-            self.github_client = GithubClient(self.token)
+            self.github_client = GithubClient(self.token, self.repo_url)
 
     def tearDown(self):
         del os.environ['GITHUB_REPOSITORY']


### PR DESCRIPTION
We would like to use this action on our GHES but since the github client defaults to github.com we're not able to use it. This adds the optional parameter to include something like `mycompany.github.com/api/v3`