### PR TITLE
fix(gha): add missing GITHUB_BASE_URL env var

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,7 @@ runs:
   image: "Dockerfile"
   env:
     OPENAI_API_KEY: ${{ inputs.openai_api_key }}
+    GITHUB_BASE_URL: ${{ inputs.github_base_url }}
     GITHUB_TOKEN: ${{ inputs.github_token }}
     GITHUB_PR_ID: ${{ inputs.github_pr_id }}
     OPENAI_MODEL: ${{ inputs.openai_model }}


### PR DESCRIPTION
The purpose of this PR is to add `GITHUB_BASE_URL` as an env var from `inputs.github_base_url`. Without it, the default base url using the public GH API and `github_base_url` inputs for GHES overrides aren't set properly.